### PR TITLE
SERVER-46008 Remove thread specific attributes feature from boost::log

### DIFF
--- a/include/boost/log/attributes/attribute_value_set.hpp
+++ b/include/boost/log/attributes/attribute_value_set.hpp
@@ -237,7 +237,9 @@ public:
      */
     BOOST_LOG_API attribute_value_set(
         attribute_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count = 8);
 
@@ -256,7 +258,9 @@ public:
      */
     BOOST_LOG_API attribute_value_set(
         attribute_value_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count = 8);
 
@@ -275,11 +279,17 @@ public:
      */
     attribute_value_set(
         BOOST_RV_REF(attribute_value_set) source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count = 8) : m_pImpl(NULL)
     {
-        construct(static_cast< attribute_value_set& >(source_attrs), thread_attrs, global_attrs, reserve_count);
+        construct(static_cast< attribute_value_set& >(source_attrs), 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+        thread_attrs, 
+#endif
+        global_attrs, reserve_count);
     }
 
     /*!
@@ -457,7 +467,9 @@ private:
     //! Constructs the object by moving from \a source_attrs. This function is mostly needed to maintain ABI stable between C++03 and C++11.
     BOOST_LOG_API void construct(
         attribute_value_set& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count);
 #endif // BOOST_LOG_DOXYGEN_PASS

--- a/include/boost/log/core/core.hpp
+++ b/include/boost/log/core/core.hpp
@@ -183,6 +183,7 @@ public:
      */
     BOOST_LOG_API void set_global_attributes(attribute_set const& attrs);
 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
     /*!
      * The method adds an attribute to the thread-specific attribute set. The attribute will be implicitly added to
      * every log record made in the current thread.
@@ -197,6 +198,7 @@ public:
      *         addition.
      */
     BOOST_LOG_API std::pair< attribute_set::iterator, bool > add_thread_attribute(attribute_name const& name, attribute const& attr);
+
     /*!
      * The method removes an attribute from the thread-specific attribute set.
      *
@@ -220,7 +222,7 @@ public:
      * \param attrs The set of attributes to be installed.
      */
     BOOST_LOG_API void set_thread_attributes(attribute_set const& attrs);
-
+#endif
     /*!
      * The method sets exception handler function. The function will be called with no arguments
      * in case if an exception occurs during either \c open_record or \c push_record method

--- a/src/attribute_value_set.cpp
+++ b/src/attribute_value_set.cpp
@@ -110,8 +110,10 @@ private:
 private:
     //! Pointer to the source-specific attributes
     attribute_set_impl_type* m_pSourceAttributes;
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
     //! Pointer to the thread-specific attributes
     attribute_set_impl_type* m_pThreadAttributes;
+#endif
     //! Pointer to the global attributes
     attribute_set_impl_type* m_pGlobalAttributes;
 
@@ -133,11 +135,15 @@ private:
         node* storage,
         node* eos,
         attribute_set_impl_type* source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set_impl_type* thread_attrs,
+#endif
         attribute_set_impl_type* global_attrs
     ) :
         m_pSourceAttributes(source_attrs),
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         m_pThreadAttributes(thread_attrs),
+#endif
         m_pGlobalAttributes(global_attrs),
         m_pEnd(storage),
         m_pEOS(eos)
@@ -154,7 +160,9 @@ private:
     static implementation* create(
         size_type element_count,
         attribute_set_impl_type* source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set_impl_type* thread_attrs,
+#endif
         attribute_set_impl_type* global_attrs)
     {
         // Calculate the buffer size
@@ -164,7 +172,11 @@ private:
 
         implementation* p = reinterpret_cast< implementation* >(stateless_allocator().allocate(buffer_size));
         node* const storage = reinterpret_cast< node* >(reinterpret_cast< char* >(p) + header_size);
-        new (p) implementation(storage, storage + element_count, source_attrs, thread_attrs, global_attrs);
+        new (p) implementation(storage, storage + element_count, source_attrs, 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+        thread_attrs, 
+#endif
+        global_attrs);
 
         return p;
     }
@@ -173,28 +185,44 @@ public:
     //! The function allocates memory and creates the object
     static implementation* create(
         attribute_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count)
     {
         return create(
-            source_attrs.m_pImpl->size() + thread_attrs.m_pImpl->size() + global_attrs.m_pImpl->size() + reserve_count,
+            source_attrs.m_pImpl->size() + 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+            thread_attrs.m_pImpl->size() + 
+#endif
+            global_attrs.m_pImpl->size() + reserve_count,
             source_attrs.m_pImpl,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
             thread_attrs.m_pImpl,
+#endif
             global_attrs.m_pImpl);
     }
 
     //! The function allocates memory and creates the object
     static implementation* create(
         attribute_value_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count)
     {
         implementation* p = create(
-            source_attrs.m_pImpl->size() + thread_attrs.m_pImpl->size() + global_attrs.m_pImpl->size() + reserve_count,
+            source_attrs.m_pImpl->size() + 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+            thread_attrs.m_pImpl->size() + 
+#endif
+            global_attrs.m_pImpl->size() + reserve_count,
             NULL,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
             thread_attrs.m_pImpl,
+#endif
             global_attrs.m_pImpl);
         p->copy_nodes_from(source_attrs.m_pImpl);
         return p;
@@ -203,13 +231,17 @@ public:
     //! The function allocates memory and creates the object
     static implementation* create(
         BOOST_RV_REF(attribute_value_set) source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         attribute_set const& thread_attrs,
+#endif
         attribute_set const& global_attrs,
         size_type reserve_count)
     {
         implementation* p = source_attrs.m_pImpl;
         source_attrs.m_pImpl = NULL;
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         p->m_pThreadAttributes = thread_attrs.m_pImpl;
+#endif
         p->m_pGlobalAttributes = global_attrs.m_pImpl;
         return p;
     }
@@ -217,14 +249,22 @@ public:
     //! The function allocates memory and creates the object
     static implementation* create(size_type reserve_count)
     {
-        return create(reserve_count, NULL, NULL, NULL);
+        return create(reserve_count, NULL, 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+        NULL, 
+#endif
+        NULL);
     }
 
     //! Creates a copy of the object
     static implementation* copy(implementation* that)
     {
         // Create new object
-        implementation* p = create(that->size(), NULL, NULL, NULL);
+        implementation* p = create(that->size(), NULL, 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+        NULL, 
+#endif
+        NULL);
 
         // Copy all elements
         p->copy_nodes_from(that);
@@ -285,11 +325,13 @@ public:
             freeze_nodes_from(m_pSourceAttributes);
             m_pSourceAttributes = NULL;
         }
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         if (m_pThreadAttributes)
         {
             freeze_nodes_from(m_pThreadAttributes);
             m_pThreadAttributes = NULL;
         }
+#endif
         if (m_pGlobalAttributes)
         {
             freeze_nodes_from(m_pGlobalAttributes);
@@ -350,6 +392,7 @@ private:
             }
         }
 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         if (m_pThreadAttributes)
         {
             it = m_pThreadAttributes->find(key);
@@ -359,6 +402,7 @@ private:
                 return insert_node(key, b, where, it->second.get_value());
             }
         }
+#endif
 
         if (m_pGlobalAttributes)
         {
@@ -472,34 +516,52 @@ BOOST_LOG_API attribute_value_set::attribute_value_set(
 //! The constructor adopts three attribute sets to the set
 BOOST_LOG_API attribute_value_set::attribute_value_set(
     attribute_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
     attribute_set const& thread_attrs,
+#endif
     attribute_set const& global_attrs,
     size_type reserve_count
 ) :
-    m_pImpl(implementation::create(source_attrs, thread_attrs, global_attrs, reserve_count))
+    m_pImpl(implementation::create(source_attrs, 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+    thread_attrs, 
+#endif
+    global_attrs, reserve_count))
 {
 }
 
 //! The constructor adopts three attribute sets to the set
 BOOST_LOG_API attribute_value_set::attribute_value_set(
     attribute_value_set const& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
     attribute_set const& thread_attrs,
+#endif
     attribute_set const& global_attrs,
     size_type reserve_count
 ) :
-    m_pImpl(implementation::create(source_attrs, thread_attrs, global_attrs, reserve_count))
+    m_pImpl(implementation::create(source_attrs, 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+    thread_attrs, 
+#endif
+    global_attrs, reserve_count))
 {
 }
 
 //! The constructor adopts three attribute sets to the set
 BOOST_LOG_API void attribute_value_set::construct(
     attribute_value_set& source_attrs,
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
     attribute_set const& thread_attrs,
+#endif
     attribute_set const& global_attrs,
     size_type reserve_count
 )
 {
-    m_pImpl = implementation::create(boost::move(source_attrs), thread_attrs, global_attrs, reserve_count);
+    m_pImpl = implementation::create(boost::move(source_attrs), 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+    thread_attrs, 
+#endif
+    global_attrs, reserve_count);
 }
 
 //! Copy constructor

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -236,8 +236,10 @@ public:
     //! Thread-specific data
     struct thread_data
     {
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
         //! Thread-specific attribute set
         attribute_set m_thread_attributes;
+#endif
         //! Random number generator for shuffling
         random::taus88 m_rng;
 
@@ -320,7 +322,9 @@ public:
 #endif
         try
         {
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
             thread_data* tsd = get_thread_data();
+#endif
 
 #if !defined(BOOST_LOG_NO_THREADS)
             // Lock the core to be safe against any attribute or sink set modifications
@@ -330,7 +334,11 @@ public:
 #endif
             {
                 // Compose a view of attribute values (unfrozen, yet)
-                attribute_value_set attr_values(boost::forward< SourceAttributesT >(source_attributes), tsd->m_thread_attributes, m_global_attributes);
+                attribute_value_set attr_values(boost::forward< SourceAttributesT >(source_attributes), 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
+                tsd->m_thread_attributes, 
+#endif
+                m_global_attributes);
                 if (m_filter(attr_values))
                 {
                     // The global filter passed, trying the sinks
@@ -567,6 +575,7 @@ BOOST_LOG_API void core::set_global_attributes(attribute_set const& attrs)
     m_impl->m_global_attributes = attrs;
 }
 
+#if !defined(BOOST_LOG_WITHOUT_THREAD_ATTR)
 //! The method adds an attribute to the thread-specific attribute set
 BOOST_LOG_API std::pair< attribute_set::iterator, bool >
 core::add_thread_attribute(attribute_name const& name, attribute const& attr)
@@ -594,6 +603,7 @@ BOOST_LOG_API void core::set_thread_attributes(attribute_set const& attrs)
     implementation::thread_data* p = m_impl->get_thread_data();
     p->m_thread_attributes = attrs;
 }
+#endif
 
 //! An internal method to set the global filter
 BOOST_LOG_API void core::set_filter(filter const& filter)


### PR DESCRIPTION
Because we prefer to compile with BOOST_LOG_USE_COMPILER_TLS for performance reasons it is not safe to log during global shutdown because of the uses of thread_local. We are not using this feature so we remove it instead of removing BOOST_LOG_USE_COMPILER_TLS and affecting the server.

The issue only affects unittests as we only do clean shutdown there.

Originally committed to mongodb/mongo in 23a5160.